### PR TITLE
generalize node damage-per-second function

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,11 +15,12 @@ local dps_nodes_names = {}
 -- that can deliver damage per second
 minetest.after(0, function()
 	for name, def in pairs(minetest.registered_nodes) do
-		if def.damage_per_second and def.damage_per_second > 0 then
+		if def.damage_per_second and def.damage_per_second ~= 0 then
 			dps_nodes_damage[name] = def.damage_per_second
 			table.insert(dps_nodes_names, name)
 		end
 	end
+	minetest.debug(dump(dps_nodes_names))
 end)
 
 local function node_dps_dmg(self)

--- a/init.lua
+++ b/init.lua
@@ -9,19 +9,6 @@ local max=math.max
 local spawn_rate = 1 - max(min(minetest.settings:get('wildlife_spawn_chance') or 0.2,1),0)
 local spawn_reduction = minetest.settings:get('wildlife_spawn_reduction') or 0.5
 
-local dps_nodes_damage = {}
-local dps_nodes_names = {}
--- After all mods are loaded and the world has been initialized, find all nodes
--- that can deliver damage per second
-minetest.after(0, function()
-	for name, def in pairs(minetest.registered_nodes) do
-		if def.damage_per_second and def.damage_per_second ~= 0 then
-			dps_nodes_damage[name] = def.damage_per_second
-			table.insert(dps_nodes_names, name)
-		end
-	end
-end)
-
 local function node_dps_dmg(self)
 	local pos = self.object:get_pos()
 	local box = self.object:get_properties().collisionbox

--- a/init.lua
+++ b/init.lua
@@ -20,7 +20,6 @@ minetest.after(0, function()
 			table.insert(dps_nodes_names, name)
 		end
 	end
-	minetest.debug(dump(dps_nodes_names))
 end)
 
 local function node_dps_dmg(self)

--- a/init.lua
+++ b/init.lua
@@ -27,11 +27,16 @@ local function node_dps_dmg(self)
 	local box = self.object:get_properties().collisionbox
 	local pos1 = {x = pos.x + box[1], y = pos.y + box[2], z = pos.z + box[3]}
 	local pos2 = {x = pos.x + box[4], y = pos.y + box[5], z = pos.z + box[6]}
-	local node_pos, node_count = minetest.find_nodes_in_area(pos1, pos2, dps_nodes_names)
+	local nodes_overlap = mobkit.get_nodes_in_area(pos1, pos2)
 	local total_damage = 0
-	for name, count in pairs(node_count) do
-		total_damage = total_damage + dps_nodes_damage[name] * count
+
+	for node_def, _ in pairs(nodes_overlap) do
+		local dps = node_def.damage_per_second
+		if dps then
+			total_damage = math.max(total_damage, dps)
+		end
 	end
+
 	if total_damage ~= 0 then
 		mobkit.hurt(self, total_damage)
 	end


### PR DESCRIPTION
I got an interesting bug report on my [magma_conduits](https://forum.minetest.net/viewtopic.php?f=11&t=20188&start=25#p367284) mod that said that the moment my mod was enabled all wildlife instantly fell over and died.

Turns out it's because my mod uses an alias to eliminate mapgen lava by turning it into air, causing this mod to treat air as lava. Which is understandably painful for most animals. :)

This pull request modifies wildlife to overcome this problem and in the process generalizes the detect-node-dps mechanism to cover all nodes that might cause harm (or, if someone adds a mod with a node that magically heals via negative dps, this should handle that too). Animals are no longer fireproof, for example.

I feel like a bit of a monster given the testing I needed to do to confirm my fix was working. Chasing down deer and setting the forest on fire around them, dumping lava on them to watch them die. The sacrifices I make for Minetest. :)